### PR TITLE
Make helicopter fly nose first

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -181,8 +181,10 @@
 
             const pressed = (action) => keyMap[action].some(key => activeKeys[key]);
 
-            if (pressed('forward')) helicopter.translateZ(-moveSpeed);
-            if (pressed('backward')) helicopter.translateZ(moveSpeed);
+            // Move the helicopter in the direction its nose is facing
+            // so pressing forward flies nose-first instead of tail-first.
+            if (pressed('forward')) helicopter.translateZ(moveSpeed);
+            if (pressed('backward')) helicopter.translateZ(-moveSpeed);
             if (pressed('left')) helicopter.rotation.y += rotationSpeed;
             if (pressed('right')) helicopter.rotation.y -= rotationSpeed;
             if (pressed('up')) helicopter.position.y += moveSpeed;
@@ -199,8 +201,8 @@
             hudSpeed.textContent = speed.toFixed(1);
             prevPosition.copy(helicopter.position);
 
-            // Update camera to follow helicopter
-            const offset = new THREE.Vector3(0, 5, 15);
+            // Update camera to follow behind the helicopter so it flies nose-first
+            const offset = new THREE.Vector3(0, 5, -15);
             const cameraPosition = offset.applyMatrix4(helicopter.matrixWorld);
             camera.position.lerp(cameraPosition, 0.1); // Smooth camera follow
             


### PR DESCRIPTION
## Summary
- Ensure forward movement translates the helicopter along its nose so it no longer flies tail-first
- Reposition the trailing camera behind the helicopter for a nose-first view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acb56cf074832cb2f8091ee1558948